### PR TITLE
Fix controls button style on small screen

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -197,7 +197,7 @@
 }
 
 .ol-touch .ol-control button {
-  font-size: 1.5em;
+  font-size: inherit;
 }
 
 .ol-touch .ol-zoom-extent {


### PR DESCRIPTION
This commit fixes .ol-touch .ol-control button font-size issue in iPad mode.


This fixes bug : https://github.com/openlayers/openlayers/issues/14459#issue-1558088636


![image](https://user-images.githubusercontent.com/32929383/214842831-9484788e-5cca-4e71-a6cb-2ecd7df993b6.png)

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
